### PR TITLE
Create WordPress-user-registration-enabled.yaml

### DIFF
--- a/exposures/files/WordPress-user-registration-enabled.yaml
+++ b/exposures/files/WordPress-user-registration-enabled.yaml
@@ -1,0 +1,21 @@
+id: WordPress user registration enabled
+
+info:
+  name: WordPress user registration enabled
+  author: Ratnadip Gajbhiye
+  severity: Medium
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/wp-login.php?action=register'
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - Register For This Site
+          - E-mail
+        part: body
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Description :
Anyone can register as a user. it's recommended to disable user registration as it caused some security issues in the past and is increasing the attack surface.

![MyTemp](https://user-images.githubusercontent.com/40835957/105161932-f663da00-5b37-11eb-9a9b-d56c056fbb82.PNG)

